### PR TITLE
[Fix] Make the settings visible again

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <settings>
-	<setting id="refresh" type="number" default="10" label="Refresh Time" visible="false" />
-	<setting id="mode" type="labelenum" default="random" label="Mode" values="random|recent" visible="false" />
+	<setting id="refresh" type="number" default="10" label="Refresh Time" visible="true" />
+	<setting id="mode" type="labelenum" default="random" label="Mode" values="random|recent" visible="true" />
 </settings>


### PR DESCRIPTION
For some reason the settings are not visible.

A number of users have asked how to change this in the Aeon Nox 5 thread so I thought it best to set the setting as visible as default so its easier for them to change.

http://forum.kodi.tv/showthread.php?tid=183504&pid=1862751#pid1862751